### PR TITLE
Backward compat with Django < 1.8

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,4 +2,4 @@ The Django Aloha Editor was original created by Bas Koopmans <e-mail@baskoopmans
 August 2011.
 
 The following is a list of much appreciated contributors:
-
+Pushkar Paranjpe <pushkarparanjpe a t  gmail dot c o m>

--- a/aloha_editor/templatetags/aloha_editor.py
+++ b/aloha_editor/templatetags/aloha_editor.py
@@ -44,10 +44,10 @@ class AlohaEditorNode(template.Node):
             # Variable was not a model
             model_name = None
         else:
-            model_name = object._meta.app_label + '_' + object._meta.module_name
+            model_name = object._meta.app_label + '_' + object._meta.model_name
 
         # Check user permissions for the object
-        permission_name = '%s.change_%s' % (object._meta.app_label, object._meta.module_name)
+        permission_name = '%s.change_%s' % (object._meta.app_label, object._meta.model_name)
         if request.user.has_perm(permission_name) or request.user.is_superuser:
             div_id = '%s-%i-%s' % (model_name, object.pk, self.variable.split('.')[-1])
             div_content = variable_ref.resolve(context)

--- a/aloha_editor/templatetags/aloha_editor.py
+++ b/aloha_editor/templatetags/aloha_editor.py
@@ -44,7 +44,10 @@ class AlohaEditorNode(template.Node):
             # Variable was not a model
             model_name = None
         else:
-            model_name = object._meta.app_label + '_' + object._meta.model_name
+            try:
+                model_name = object._meta.app_label + '_' + object._meta.model_name
+            except AttributeError:
+                model_name = object._meta.app_label + '_' + object._meta.module_name
 
         # Check user permissions for the object
         permission_name = '%s.change_%s' % (object._meta.app_label, object._meta.model_name)

--- a/aloha_editor/views.py
+++ b/aloha_editor/views.py
@@ -51,4 +51,9 @@ def save_editable(request):
     else:
         response_dict = { 'success': False }
 
-    return HttpResponse(json.dumps(response_dict), content_type='application/javascript')
+    try:
+        response = HttpResponse(json.dumps(response_dict), content_type='application/javascript')
+    except TypeError:
+        response = HttpResponse(json.dumps(response_dict), mimetype='application/javascript') 
+
+    return response

--- a/aloha_editor/views.py
+++ b/aloha_editor/views.py
@@ -51,4 +51,4 @@ def save_editable(request):
     else:
         response_dict = { 'success': False }
 
-    return HttpResponse(json.dumps(response_dict), mimetype='application/javascript')
+    return HttpResponse(json.dumps(response_dict), content_type='application/javascript')


### PR DESCRIPTION
###### aloha_editor.py
```python
    try:
        model_name = object._meta.app_label + '_' + object._meta.model_name
    except AttributeError:
        model_name = object._meta.app_label + '_' + object._meta.module_name
```
&

###### views.py
```python  
  try:
        response = HttpResponse(json.dumps(response_dict), content_type='application/javascript')
    except TypeError:
        response = HttpResponse(json.dumps(response_dict), mimetype='application/javascript') 
```