### PR TITLE
Major update: works with the latest aloha.js, forward compat with Django >= 1.9 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,8 @@ Installation
 
 	``url(r'^__alohaeditor__/', include('aloha_editor.urls', namespace='aloha_editor')),``
 
+
+
 #. Add ``aloha_editor`` to your ``INSTALLED_APPS`` setting so Django can find the
    template files and template tags associated with Aloha Editor.
 

--- a/aloha_editor/__init__.py
+++ b/aloha_editor/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (1, 1, 0)
+VERSION = (1, 1, 1)
 __version__ = '.'.join(map(str, VERSION))

--- a/aloha_editor/__init__.py
+++ b/aloha_editor/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (1, 0, 0)
+VERSION = (1, 1, 0)
 __version__ = '.'.join(map(str, VERSION))

--- a/aloha_editor/templates/aloha_editor/css.html
+++ b/aloha_editor/templates/aloha_editor/css.html
@@ -1,4 +1,4 @@
-<link type="text/css" href="http://cdn.aloha-editor.org/latest/css/aloha.css" rel="stylesheet">
+<!--<link type="text/css" href="http://cdn.aloha-editor.org/latest/css/aloha.css" rel="stylesheet">-->
 <style type="text/css">
   .aloha-editable-highlight { outline: 0 !important; }
   .aloha-editable:hover { outline: #45B7DF solid 2px !important; }

--- a/aloha_editor/templates/aloha_editor/js.html
+++ b/aloha_editor/templates/aloha_editor/js.html
@@ -1,4 +1,4 @@
-<script type="text/javascript" src="http://cdn.aloha-editor.org/latest/lib/require.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.js"></script>
 <script type="text/javascript" >
   var Aloha = window.Aloha || ( window.Aloha = {} );
   Aloha.settings = {
@@ -82,7 +82,7 @@
     }
   };
 </script>
-<script type="text/javascript" src="http://cdn.aloha-editor.org/latest/lib/aloha.js"
+<script type="text/javascript" src="http://www.alohaeditor.org/download/aloha.min.js"
   data-aloha-plugins="common/ui,
     common/format,
     common/table,
@@ -98,25 +98,31 @@
     common/abbr">
 </script>
 <script type="text/javascript">
-  Aloha.ready( function() {
-    Aloha.jQuery('.aloha_editable').aloha();
     // save all changes after leaving an editable
-    Aloha.bind('aloha-editable-deactivated', function(){
-      var request = jQuery.ajax({
-        url: "{% url 'aloha_editor:save_editable' %}",
-        type: "POST",
-        data: {
-          editable_content : Aloha.activeEditable.getContents(),
-          editable_reference : Aloha.activeEditable.obj[0].id,
-        },
-        dataType: "html"
-      });
-      request.done(function(result) {
-        var result = jQuery.parseJSON(result)
-      });
-      request.error(function(jqXHR, textStatus) {
-        alert( "Request failed: " + textStatus );
-      });
-    });
-  });
+    function middleware(event) {
+        // console.log(event);
+        if (event.type == "leave"){
+            // console.log("Saving ...");
+              var request = jQuery.ajax({
+                url: "{% url 'aloha_editor:save_editable' %}",
+                type: "POST",
+                data: {
+                  editable_content : event.editable.elem.innerHTML,
+                  editable_reference : event.editable.elem.id,
+                },
+                dataType: "html"
+              });
+              request.done(function(result) {
+                var result = jQuery.parseJSON(result)
+              });
+              request.error(function(jqXHR, textStatus) {
+                alert( "Request failed: " + textStatus );
+              });
+        }
+        return event;
+    }
+
+    aloha(document.querySelector('.aloha_editable'));
+    aloha.editor.stack.unshift(middleware);
+
 </script>

--- a/aloha_editor/templates/aloha_editor/js.html
+++ b/aloha_editor/templates/aloha_editor/js.html
@@ -122,7 +122,8 @@
         return event;
     }
 
-    aloha(document.querySelector('.aloha_editable'));
+    // console.log($('.aloha_editable'));
+    aloha.dom.query('.aloha_editable', document).map(aloha);
     aloha.editor.stack.unshift(middleware);
 
 </script>

--- a/aloha_editor/urls.py
+++ b/aloha_editor/urls.py
@@ -1,9 +1,15 @@
 # encoding: utf-8
 
 from django.conf.urls import patterns, url
-from django.conf import settings
+import django
 
 
-urlpatterns = patterns('',
-    url(r'save_editable/$', 'aloha_editor.views.save_editable', name='save_editable'),
-)
+if django.VERSION >= (1, 9, 0, ):
+    from .views import save_editable
+    urlpatterns = [
+        url(r'save_editable/$', save_editable, name='save_editable'),
+    ]
+else:
+    urlpatterns = patterns('',
+        url(r'save_editable/$', 'aloha_editor.views.save_editable', name='save_editable'),
+    )

--- a/aloha_editor/views.py
+++ b/aloha_editor/views.py
@@ -2,11 +2,16 @@
 
 import os
 import json
-
 from django.conf import settings
-from django.db.models import get_model
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_protect, csrf_exempt
+
+import django
+if django.VERSION >= (1, 9, 0, ):
+    from django.apps import apps
+    get_model = apps.get_model
+else:
+    from django.db.models import get_model
 
 
 #@csrf_protect


### PR DESCRIPTION
>   modified:   aloha_editor/**init**.py  

```
Bumped up the minor version code.  
```

>   modified:   aloha_editor/templates/aloha_editor/css.html  

```
Commented out the CSS asset import, since it no longer exists.  
```

>   modified:   aloha_editor/templates/aloha_editor/js.html  

```
Updated the CDN for require.js  
Updated the source for aloha.js  
Aloha.js has undergone significant change. Adapted the js.html to use the new 'middleware' design pattern of aloha.ui.  
```

>   modified:   aloha_editor/urls.py  

```
Future compat with Django >= 1.9, while maintaining backward compat.  
```

>   modified:   aloha_editor/views.py  

```
Future compat with Django >= 1.9, while maintaining backward compat.    
```
